### PR TITLE
colorConsistency: fix wrapper logic

### DIFF
--- a/src/colorConsistency/webpackModules/wrapper.tsx
+++ b/src/colorConsistency/webpackModules/wrapper.tsx
@@ -27,13 +27,13 @@ export default function ColorConsistencyWrapper({
     userId,
     guildId
   ]);
-  const { colorString, colorStrings } = member;
-  const shouldUseGradient = colorStrings && colorStrings.primaryColor && colorStrings.secondaryColor;
+  const { colorString, colorStrings } = member ?? {};
+  const shouldUseGradient = colorStrings?.primaryColor && colorStrings.secondaryColor;
   const { text, gradient } =
     useGradient?.(colorStrings?.primaryColor, colorStrings?.secondaryColor, colorStrings?.tertiaryColor, "username") ??
     {};
 
-  if (!member || !colorString || colorString === "") return children;
+  if (!member || !colorString) return children;
 
   return (
     <span


### PR DESCRIPTION
A major fix (attempt to destructure `null`) and a couple of logic improvements.

`webpackModules/wrapper.tsx`:
- Use `??` to prevent destructing `member` if it is null.
- Use `?.` for `shouldUseGradient`.
- Remove an extra check for the guard clause.

If you think this should be changed to removing the `!member` check from the existing guard clause and instead move it to a new one directly after `const member = ...;` whilst ditching the `??` on destructure, let me know and I will rebase.
