### PR TITLE
Add GIF Auto Favorites setting to Media Tweaks

### DIFF
--- a/src/mediaTweaks/index.ts
+++ b/src/mediaTweaks/index.ts
@@ -24,7 +24,7 @@ export const patches: Patch[] = [
     find: '"state",{resultType:',
     replace: [{
       match: /(?<="state",{resultType:)null/,
-      replacement: (orig: string) => `(moonlight.getConfigOption("mediaTweaks","gifAutoFavorites")??true?"Favorites":${orig})`
+      replacement: (orig: string) => `(moonlight.getConfigOption("mediaTweaks","gifAutoFavorites")??false?"Favorites":${orig})`
     }]
   },
 

--- a/src/mediaTweaks/index.ts
+++ b/src/mediaTweaks/index.ts
@@ -19,6 +19,15 @@ export const patches: Patch[] = [
     }
   },
 
+  // GIF Auto Favorites
+  {
+    find: '"state",{resultType:',
+    replace: [{
+      match: /(?<="state",{resultType:)null/,
+      replacement: (orig: string) => `(moonlight.getConfigOption("mediaTweaks","gifAutoFavorites")??true?"Favorites":${orig})`
+    }]
+  },
+
   // Video Metadata
   {
     find: "renderMetadata()",

--- a/src/mediaTweaks/manifest.json
+++ b/src/mediaTweaks/manifest.json
@@ -26,6 +26,13 @@
       "default": true,
       "advice": "none"
     },
+    "gifAutoFavorites": {
+      "displayName": "GIF Default to Favorites",
+      "description": "Automatically opens the favorites tab in the GIF picker",
+      "type": "boolean",
+      "default": false,
+      "advice": "none"
+    },
     "videoMetadata": {
       "displayName": "Video Metadata",
       "description": "Restores filename and filesize on video attachments",


### PR DESCRIPTION
Ported from [this Vencord Plugin](https://github.com/Vendicated/Vencord/blob/main/src/plugins/betterGifPicker/index.ts)

It felt appropriate to be a part of Media Tweaks